### PR TITLE
Fix broken links/paths to zephyr in documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ Supported Platforms
 
 * ATM33xx_
 
-.. _ATM33xx: https://github.com/Atmosic/zephyr/blob/HEAD/boards/arm/atm33evk/doc/index.rst
+.. _ATM33xx: https://github.com/Atmosic/zephyr/blob/HEAD/boards/atmosic/atm33evk/doc/index.rst
 
 Creating a Workspace
 ********************
@@ -25,4 +25,4 @@ To create an Atmosic SDK workspace, first follow the instructions_ from the offi
 
 .. _instructions: https://docs.zephyrproject.org/latest/develop/getting_started/index.html
 
-Refer to the `Supported Platforms`_ documentation for details on how to build and program an application.  For example, see the section on `programming and debugging an ATM33xx <https://github.com/Atmosic/zephyr/blob/HEAD/boards/arm/atm33evk/doc/index.rst#programming-and-debugging>`_ EVK.
+Refer to the `Supported Platforms`_ documentation for details on how to build and program an application.  For example, see the section on `programming and debugging an ATM33xx <https://github.com/Atmosic/zephyr/blob/HEAD/boards/atmosic/atm33evk/doc/index.rst#programming-and-debugging>`_ EVK.

--- a/samples/spe/README.rst
+++ b/samples/spe/README.rst
@@ -97,7 +97,7 @@ atm33evk
 A convenient support script is provided in the Zephyr repository to build and
 program this application. Please refer to::
 
-   zephyr/boards/arm/atm33evk/doc/index.rst
+   zephyr/boards/atmosic/atm33evk/doc/index.rst
 
 Below are the steps for building and programming this application without
 MCUBoot using ``west build`` and ``west flash`` directly.


### PR DESCRIPTION
Links/paths were broken post-3.7.0 merge.