### PR TITLE
Fix broken links in documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,8 +13,8 @@ Supported Platforms
 * ATMx2xx_
 * ATM33xx_
 
-.. _ATMx2xx: https://github.com/Atmosic/zephyr/blob/HEAD/boards/atmosic/atmevk-02/doc/index.rst
-.. _ATM33xx: https://github.com/Atmosic/zephyr/blob/HEAD/boards/atmosic/atm33evk/doc/index.rst
+.. _ATMx2xx: boards/atmosic/atmevk-02/doc/index.rst
+.. _ATM33xx: boards/atmosic/atm33evk/doc/index.rst
 
 Creating a Workspace
 ********************
@@ -27,4 +27,4 @@ To create an Atmosic SDK workspace, first follow the instructions_ from the offi
 
 .. _instructions: https://docs.zephyrproject.org/latest/develop/getting_started/index.html
 
-Refer to the `Supported Platforms`_ documentation for details on how to build and program an application.  For example, see the section on `programming and debugging an ATM33xx <https://github.com/Atmosic/zephyr/blob/HEAD/boards/atmosic/atm33evk/doc/index.rst#programming-and-debugging>`_ EVK.
+Refer to the `Supported Platforms`_ documentation for details on how to build and program an application.  For example, see the section on `programming and debugging an ATM33xx </boards/atmosic/atm33evk/doc/index.rst#programming-and-debugging>`_ EVK.

--- a/samples/bluetooth/hci_vendor/README.rst
+++ b/samples/bluetooth/hci_vendor/README.rst
@@ -63,9 +63,9 @@ in modules/hal/atmosic/ATM33xx-5/drivers/ble for information on the controller
 images and library options.
 
 A convenient support script is provided in the Zephyr repository to build and
-program this application. Please refer to::
-
-   openair/boards/arm/atm33evk/doc/index.rst
+program this application. Please refer to the documentation on `programming and
+debugging an ATM33xx
+</boards/atmosic/atm33evk/doc/index.rst#programming-and-debugging>`_ EVK.
 
 Below are the steps for building and programming this application without
 MCUBoot using ``west build`` and ``west flash`` directly.

--- a/samples/spe/README.rst
+++ b/samples/spe/README.rst
@@ -95,9 +95,9 @@ atm33evk
 --------
 
 A convenient support script is provided in the Zephyr repository to build and
-program this application. Please refer to::
-
-   zephyr/boards/atmosic/atm33evk/doc/index.rst
+program this application. Please refer to the documentation on `programming and
+debugging an ATM33xx
+</boards/atmosic/atm33evk/doc/index.rst#programming-and-debugging>`_ EVK.
 
 Below are the steps for building and programming this application without
 MCUBoot using ``west build`` and ``west flash`` directly.


### PR DESCRIPTION
Update the links to various platform documentation READMEs after they were moved out of the zephyr tree and into openair.