### PR TITLE
[SOFTWARE-8090]sdk version of atm file parsing from git tag should not be limited by expected prefix

### DIFF
--- a/tools/scripts/atm_isp
+++ b/tools/scripts/atm_isp
@@ -485,7 +485,7 @@ class Tools:
     def get_zephyr_ver(version):
         # git tag => github_atmosic/24.04.0 or 24.04.0
         git_cmd = "git for-each-ref --sort=creatordate --format='%(refname)'"
-        pattern = r'refs/tags/(?:github_atmosic/)(\d+)\.(\d+)\.(\d+)'
+        pattern = r'refs/tags/(?:github_atmosic/|release/)?(\d+)\.(\d+)\.(\d+)'
         try:
             process = subprocess.Popen(git_cmd, shell=True,
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)


### PR DESCRIPTION
Update sdk version of atm file parsing rule to be “<YY>.<MM>.<patch>“.  No code should depend on github_atmosic/ or even release/ being part of the tag prefix