### PR TITLE
[SOFTWARE-8950] Modify overlay path and set SB_CONFIG_ATMWSTK_FULL=y

### DIFF
--- a/applications/ras_rreq_initiator/sample.yaml
+++ b/applications/ras_rreq_initiator/sample.yaml
@@ -13,13 +13,15 @@ tests:
     tags: atm34 no_mcuboot
     extra_args:
       - SB_CONFIG_SPE=y
-      - spe_DTC_OVERLAY_FILE=${ZEPHYR_ATMOSIC_PRIVATE_MODULE_DIR}/applications/ras_rreq_initiator/boards/${BOARD}_spe_uart0.overlay
+      - SB_CONFIG_ATMWSTK_FULL=y
+      - spe_DTC_OVERLAY_FILE=${ZEPHYR_OPENAIR_MODULE_DIR}/applications/ras_rreq_initiator/boards/${BOARD}_spe_uart0.overlay
     extra_configs:
       - CONFIG_ATM_SOC_ALLOW="ATM34"
   applications.ras_rreq_initiator.atm.atmwstklib.full.uart1:
     tags: atm34 no_mcuboot
     extra_args:
       - SB_CONFIG_SPE=y
+      - SB_CONFIG_ATMWSTK_FULL=y
       - EXTRA_DTC_OVERLAY_FILE=boards/${BOARD}_ns_uart1.overlay
     extra_configs:
       - CONFIG_ATM_SOC_ALLOW="ATM34"

--- a/applications/ras_rreq_initiator/src/rreq_smf.c
+++ b/applications/ras_rreq_initiator/src/rreq_smf.c
@@ -875,8 +875,8 @@ static void rreq_start_scan(void)
 
 static void rreq_scan_entry(void *obj)
 {
-	LOG_INF("scan entry");
 	rreq_start_scan();
+	LOG_INF("scan entry");
 }
 
 static void rreq_scan_run(void *obj)


### PR DESCRIPTION
Fix sysbuild failure and wrong ATMWSTK for ras_rreq_initiator