### PR TITLE
SOFTWARE-8982

### DIFF
--- a/modules/hal_atmosic/ATM34xx/drivers/pc_ll_cfg/Kconfig
+++ b/modules/hal_atmosic/ATM34xx/drivers/pc_ll_cfg/Kconfig
@@ -21,7 +21,6 @@ config ATM_ENA_LL_FEAT_CS
 config ATM_ENA_LL_FEAT_ISO
 	bool "When available, enable LL ISO feature"
 	default y if SOC_SERIES_ATM34 && ATMWSTK_FULL
-	default y if SOC_SERIES_ATM13
 	default n
 
 endif # ATM_PC_LL_CFG


### PR DESCRIPTION
This is an out-of-date chip reference, and should be removed. See also https://atmosic.atlassian.net/browse/SOFTWARE-8982