### PR TITLE
[support-4388] fp_tag spelling error

### DIFF
--- a/applications/fp_tag/sample.yaml
+++ b/applications/fp_tag/sample.yaml
@@ -7,7 +7,7 @@ common:
   harness_config:
     type: one_line
     regex:
-      - "Press button to start paring"
+      - "Press button to start pairing"
 tests:
   applications.fp_tag.atm:
     tags: fp_tag atm33 atm34 no_mcuboot

--- a/lib/atm_gfp/atm_gfp.c
+++ b/lib/atm_gfp/atm_gfp.c
@@ -207,7 +207,7 @@ static void atm_gfp_service_init(void)
 			atm_gfp_hdlrs->mode_state_cb(FP_MODE_NONE);
 		}
 #else
-		LOG_INF("Press button to start paring");
+		LOG_INF("Press button to start pairing");
 #endif
 	}
 }

--- a/lib/atm_gfp/atm_gfp.h
+++ b/lib/atm_gfp/atm_gfp.h
@@ -26,7 +26,7 @@ typedef struct atm_gfp_hdlrs_s {
 	/// play sound callback function
 	void (*sound_action_cb)(bool action);
 #ifdef CONFIG_ATM_GFP_MUTLIMODE_TAG
-	/// paring in progress callback function
+	/// pairing in progress callback function
 	void (*mode_state_cb)(fp_mode_t mode);
 #endif
 } atm_gfp_hdlrs_t;

--- a/subsys/bluetooth/services/gfp/fmdn/fp_fmdn_gatt.h
+++ b/subsys/bluetooth/services/gfp/fmdn/fp_fmdn_gatt.h
@@ -58,7 +58,7 @@ void fp_fmdn_bcna_ccc_cfg_changed(const struct bt_gatt_attr *attr, uint16_t valu
 
 /**
  * @brief The callback function of utp mode notify
- * @param[in] mode fast paring itp mode
+ * @param[in] mode fast pairing itp mode
  */
 typedef void (*fp_fmdn_utp_mode_cb)(fp_fmdn_utp_mode_t mode);
 

--- a/subsys/bluetooth/services/gfp/fmdn/fp_fmdn_key.h
+++ b/subsys/bluetooth/services/gfp/fmdn/fp_fmdn_key.h
@@ -124,7 +124,7 @@ void fp_fmdn_key_update_eid(void);
 
 /**
  * @brief The callback function of battery status
- * @param[in] mode fast paring itp mode
+ * @param[in] mode fast pairing itp mode
  */
 typedef uint8_t (*fp_fmdn_battery_cb)(void);
 

--- a/subsys/bluetooth/services/gfp/fp_common.h
+++ b/subsys/bluetooth/services/gfp/fp_common.h
@@ -54,9 +54,9 @@ enum {
 typedef enum {
 	/// Index of Google Fast Pair initial mode
 	FP_MODE_NONE = 0x00,
-	/// Index of Google Fast Pair in paring mode
+	/// Index of Google Fast Pair in pairing mode
 	FP_MODE_PAIRING,
-	/// Index of Google Fast Pair in paring process mode
+	/// Index of Google Fast Pair in pairing process mode
 	FP_MODE_PAIRING_PROCESSING,
 	/// Index of Google Fast Pair paired mode
 	FP_MODE_PAIRED,

--- a/subsys/bluetooth/services/gfp/fp_gatt.c
+++ b/subsys/bluetooth/services/gfp/fp_gatt.c
@@ -144,11 +144,11 @@ static int fp_kbp_req_handler(struct bt_conn *conn, struct net_buf_simple *rsp,
 #define REQ_ADDTION_NAME_NOTIFY            0b00000010
 #define REQ_ETROACTIVELY_WRITE_ACCOUNT_KEY 0b00000100
 		if (req->flags & REQ_INITIALING_BONDING) {
-			LOG_DBG("Subsequece paring not support");
+			LOG_DBG("Subsequece pairing not supported");
 			pairing_req = false;
 		}
 		if (req->flags & REQ_ADDTION_NAME_NOTIFY) {
-			LOG_DBG("Addition Name Notify not support");
+			LOG_DBG("Addition Name Notify not supported");
 			*do_addi_act = false;
 		}
 		if (req->flags & REQ_ETROACTIVELY_WRITE_ACCOUNT_KEY) {

--- a/subsys/bluetooth/services/gfp/fp_mode.h
+++ b/subsys/bluetooth/services/gfp/fp_mode.h
@@ -67,7 +67,7 @@ bool fp_mode_is_pairing(void);
 
 /**
  * @brief The callback function of mode switch notify
- * @param[in] mode fast paring mode
+ * @param[in] mode fast pairing mode
  */
 typedef void (*fp_mode_switch_cb)(fp_mode_t mode);
 


### PR DESCRIPTION
Fix spelling error pairing

This PR fixes spelling errors where "paring" was incorrectly used instead of "pairing" in various files related to Google Fast Pair functionality.

**Changes:**
- Fixed spelling in `applications/fp_tag/sample.yaml`
- Fixed spelling in `lib/atm_gfp/atm_gfp.c`
- Fixed spelling in `lib/atm_gfp/atm_gfp.h`
- Fixed spelling in `subsys/bluetooth/services/gfp/fmdn/fp_fmdn_gatt.h`
- Fixed spelling in `subsys/bluetooth/services/gfp/fmdn/fp_fmdn_key.h`
- Fixed spelling in `subsys/bluetooth/services/gfp/fp_common.h`
- Fixed spelling in `subsys/bluetooth/services/gfp/fp_gatt.c`
- Fixed spelling in `subsys/bluetooth/services/gfp/fp_mode.h`

**Test Jobs:**
- Atm-Job: /Tools/Zephyr/sphinx-doc
- Atm-job: /paris_2.1/paris_zephyr_sysbuild
- Atm-job: /perth_2.0/perth_zephyr_sysbuild

Change-Id: Ie00543e18b12f9d85deac3529c5750c9ebc77953

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author