### PR TITLE
[SOFTWARE-9004] ATM33:: openair/samples/bluetooth/hci_vendor sample fails with halt error

### DIFF
--- a/lib/atm_hci_uart/Kconfig
+++ b/lib/atm_hci_uart/Kconfig
@@ -15,12 +15,12 @@ source "subsys/logging/Kconfig.template.log_config"
 config ATM_VENDOR_TX_STACK_SIZE
 	int "ATM hci uart tx thread stack size"
 	default 2048 if COVERAGE
-	default 400
+	default 1792
 
 config ATM_VENDOR_RX_STACK_SIZE
 	int "ATM hci uart rx thread stack size"
 	default 2048 if COVERAGE
-	default 800
+	default 1792
 
 choice
 	prompt "Atmosic HCI UART DEVICE"


### PR DESCRIPTION

-) Bump up ATM_VENDOR_TX_STACK_SIZE and ATM_VENDOR_RX_STACK_SIZE.

Atm-Job: noFailFast
Atm-Job: /paris_2.1/paris_zephyr_sysbuild
Atm-Job: /paris_2.1/paris_zephyr_atm
Atm-Job: /paris_2.1/paris_atmx3_zephyr_tests
Atm-Job: /paris_2.1/paris_atmx3_zephyr_sysbuild_tests
Atm-Job: /perth_2.0/perth_zephyr_sysbuild
Atm-Job: /perth_2.0/perth_zephyr_atm
Atm-Job: /perth_2.0/perth_atm34_zephyr_tests
Atm-Job: /perth_2.0/perth_atm34_zephyr_sysbuild_tests
Atm-Job: /perth_2.0/perth_two_atm34_zephyr_ble_tests

Change-Id: Ia5fb08d21ab209034c11a9d2783b816e4d762575