### PR TITLE
Remove path separators in fast_code relocations

### DIFF
--- a/soc/atmosic/ATM34/linker.ld
+++ b/soc/atmosic/ATM34/linker.ld
@@ -36,18 +36,18 @@ MEMORY {
 
 SECTIONS {
     fast_code : {
-	*/libarch*.a:(.text ".text.*" .rodata ".rodata.*")
-	*/libblell*.a:(.text ".text.*" .rodata ".rodata.*")
-	*/libc*.a:(.text ".text.*" .rodata ".rodata.*")
-	*/libdrivers*.a:(.text ".text.*" .rodata ".rodata.*")
-	*/libgcc.a:(.text ".text.*" .rodata ".rodata.*")
-	*/libkernel.a:(.text ".text.*" .rodata ".rodata.*")
-	*/libmbedTLS*.a:(.text ".text.*" .rodata ".rodata.*")
-	*/lib*mbedtls.a:(.text ".text.*" .rodata ".rodata.*")
-	*/lib*net_buf*.a:(.text ".text.*" .rodata ".rodata.*")
-	*/libopenthread*.a:(.text ".text.*" .rodata ".rodata.*")
-	*/libsubsys*.a:(.text ".text.*" .rodata ".rodata.*")
-	*/libzephyr.a:(.text ".text.*" .rodata ".rodata.*")
+	*libarch*.a:(.text ".text.*" .rodata ".rodata.*")
+	*libblell*.a:(.text ".text.*" .rodata ".rodata.*")
+	*libc*.a:(.text ".text.*" .rodata ".rodata.*")
+	*libdrivers*.a:(.text ".text.*" .rodata ".rodata.*")
+	*libgcc.a:(.text ".text.*" .rodata ".rodata.*")
+	*libkernel.a:(.text ".text.*" .rodata ".rodata.*")
+	*libmbedTLS*.a:(.text ".text.*" .rodata ".rodata.*")
+	*lib*mbedtls.a:(.text ".text.*" .rodata ".rodata.*")
+	*lib*net_buf*.a:(.text ".text.*" .rodata ".rodata.*")
+	*libopenthread*.a:(.text ".text.*" .rodata ".rodata.*")
+	*libsubsys*.a:(.text ".text.*" .rodata ".rodata.*")
+	*libzephyr.a:(.text ".text.*" .rodata ".rodata.*")
 	*_core.po(.text ".text.*" .rodata ".rodata.*")
 	. = ALIGN(4);
     } > RRAM


### PR DESCRIPTION
Remove leading separators that can cause a mismatch on Windows environments